### PR TITLE
Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ UX Aspects Seed Project provides a skeleton which can be used to build an applic
 
 ##### Install with Bower
 * Install [Git](https://git-scm.com/downloads)
-* run ``` git clone https://github.com/UXAspects/UXAspects  ```
+* run `git clone https://github.com/UXAspects/UXAspects-Seed`
 * Install [Nodejs](https://nodejs.org/en/)
   * Note: Node comes with [npm](https://docs.npmjs.com/getting-started/installing-node) installed but npm is updated more frequently than Node
-* Run  ```npm install``` from the folder where the code will be downloaded
-* Install [bower(>v1.5)](http://bower.io/#install-bower) using npm ```npm install -g bower```
-* Run ```bower install``` in the seed project folder
-* Run ```npm start```
-* Browse "http://localhost:8080/webpack-dev-server/"
+* Run  `npm install` from the folder where the code will be downloaded
+* Install [bower(>v1.5)](http://bower.io/#install-bower) using npm `npm install -g bower`
+* Run `bower install` in the seed project folder
+* Run `npm start`
+* Browse "http://localhost:8080/"


### PR DESCRIPTION
- Fixed the git clone instruction.
- Changed to use single ticks instead of triple ticks as they should be used for inline snippets
- Removing webpack-dev-server from launch url, as it is not needed due to built in refresh functionality